### PR TITLE
Set hand range to 0 to disable node highlighting.

### DIFF
--- a/mods/game/init.lua
+++ b/mods/game/init.lua
@@ -89,6 +89,7 @@ minetest.register_item(":", {
 	type = "none",
 	wield_image = "inv.png",
 	groups = {not_in_creative_inventory=1},
+	range = 0
 })
 
 --Style Registrations


### PR DESCRIPTION
This PR sets the hand range to 0 which disables any form of node highlighting (outline or glow). I find this to increase the immersion as you can't as easily see node corners now.